### PR TITLE
Start of utilities to help plugin developers manage ESR payloads

### DIFF
--- a/test/tests/utils.ts
+++ b/test/tests/utils.ts
@@ -1,0 +1,150 @@
+import {assert} from 'chai'
+
+import zlib from 'pako'
+
+import {SigningRequest, Transaction} from '$lib'
+import {makeMockAction} from '$test/utils/mock-transfer'
+
+import {appendAction, prependAction} from 'src/utils'
+import {mockData} from '$test/utils/mock-data'
+
+const newAction = makeMockAction('new action')
+
+function commonAsserts(
+    original: Transaction,
+    modified: Transaction,
+    oldActions = 1,
+    newActions = 2
+) {
+    // Ensure no data besides the actions has changed
+    original.context_free_actions.forEach((action, index) => {
+        assert.isTrue(action.equals(modified.context_free_actions[index]))
+    })
+    modified.context_free_actions.forEach((action, index) => {
+        assert.isTrue(action.equals(original.context_free_actions[index]))
+    })
+    assert.isTrue(original.delay_sec.equals(modified.delay_sec))
+    assert.isTrue(original.expiration.equals(modified.expiration))
+    assert.isTrue(!original.id.equals(modified.id))
+    assert.isTrue(original.max_cpu_usage_ms.equals(modified.max_cpu_usage_ms))
+    assert.isTrue(original.max_net_usage_words.equals(modified.max_net_usage_words))
+    assert.isTrue(original.ref_block_num.equals(modified.ref_block_num))
+    assert.isTrue(original.ref_block_prefix.equals(modified.ref_block_prefix))
+    original.transaction_extensions.forEach((extension, index) => {
+        assert.isTrue(extension.equals(modified.transaction_extensions[index]))
+    })
+    modified.transaction_extensions.forEach((extension, index) => {
+        assert.isTrue(extension.equals(original.transaction_extensions[index]))
+    })
+
+    // Ensure the original transaction remains
+    assert.equal(original.actions.length, oldActions)
+
+    // Ensure the modified transaction updated correctly
+    assert.equal(modified.actions.length, newActions)
+}
+
+suite('utils', function () {
+    suite('appendAction', function () {
+        test('payload w/ action', async function () {
+            const {action} = await mockData('old action')
+            const request = await SigningRequest.create(
+                {
+                    action,
+                    chainId: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+                },
+                {zlib}
+            )
+            const originalTransaction = request.getRawTransaction()
+            const modifiedRequest = appendAction(request, newAction)
+            const modifiedTransaction = modifiedRequest.getRawTransaction()
+            commonAsserts(originalTransaction, modifiedTransaction)
+            assert.isTrue(originalTransaction.actions[0].equals(modifiedTransaction.actions[0]))
+            assert.isTrue(newAction.equals(modifiedTransaction.actions[1]))
+        })
+        test('payload w/ actions', async function () {
+            const {action} = await mockData('old action')
+            const request = await SigningRequest.create(
+                {
+                    actions: [action, action],
+                    chainId: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+                },
+                {zlib}
+            )
+            const originalTransaction = request.getRawTransaction()
+            const modifiedRequest = appendAction(request, newAction)
+            const modifiedTransaction = modifiedRequest.getRawTransaction()
+            commonAsserts(originalTransaction, modifiedTransaction, 2, 3)
+            assert.isTrue(originalTransaction.actions[0].equals(modifiedTransaction.actions[0]))
+            assert.isTrue(originalTransaction.actions[1].equals(modifiedTransaction.actions[1]))
+            assert.isTrue(newAction.equals(modifiedTransaction.actions[2]))
+        })
+        test('payload w/ transaction', async function () {
+            const {transaction} = await mockData('old action')
+            const request = await SigningRequest.create(
+                {
+                    transaction,
+                    chainId: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+                },
+                {zlib}
+            )
+            const originalTransaction = request.getRawTransaction()
+            const modifiedRequest = appendAction(request, newAction)
+            const modifiedTransaction = modifiedRequest.getRawTransaction()
+            commonAsserts(originalTransaction, modifiedTransaction)
+            assert.isTrue(originalTransaction.actions[0].equals(modifiedTransaction.actions[0]))
+            assert.isTrue(newAction.equals(modifiedTransaction.actions[1]))
+        })
+    })
+    suite('prependAction', function () {
+        test('payload w/ action', async function () {
+            const {action} = await mockData('old action')
+            const request = await SigningRequest.create(
+                {
+                    action,
+                    chainId: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+                },
+                {zlib}
+            )
+            const originalTransaction = request.getRawTransaction()
+            const modifiedRequest = prependAction(request, newAction)
+            const modifiedTransaction = modifiedRequest.getRawTransaction()
+            commonAsserts(originalTransaction, modifiedTransaction)
+            assert.isTrue(newAction.equals(modifiedTransaction.actions[0]))
+            assert.isTrue(originalTransaction.actions[0].equals(modifiedTransaction.actions[1]))
+        })
+        test('payload w/ actions', async function () {
+            const {action} = await mockData('old action')
+            const request = await SigningRequest.create(
+                {
+                    actions: [action, action],
+                    chainId: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+                },
+                {zlib}
+            )
+            const originalTransaction = request.getRawTransaction()
+            const modifiedRequest = prependAction(request, newAction)
+            const modifiedTransaction = modifiedRequest.getRawTransaction()
+            commonAsserts(originalTransaction, modifiedTransaction, 2, 3)
+            assert.isTrue(newAction.equals(modifiedTransaction.actions[0]))
+            assert.isTrue(originalTransaction.actions[0].equals(modifiedTransaction.actions[1]))
+            assert.isTrue(originalTransaction.actions[1].equals(modifiedTransaction.actions[2]))
+        })
+        test('payload w/ transaction', async function () {
+            const {transaction} = await mockData('old action')
+            const request = await SigningRequest.create(
+                {
+                    transaction,
+                    chainId: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+                },
+                {zlib}
+            )
+            const originalTransaction = request.getRawTransaction()
+            const modifiedRequest = prependAction(request, newAction)
+            const modifiedTransaction = modifiedRequest.getRawTransaction()
+            commonAsserts(originalTransaction, modifiedTransaction)
+            assert.isTrue(newAction.equals(modifiedTransaction.actions[0]))
+            assert.isTrue(originalTransaction.actions[0].equals(modifiedTransaction.actions[1]))
+        })
+    })
+})

--- a/test/utils/mock-data.ts
+++ b/test/utils/mock-data.ts
@@ -1,0 +1,22 @@
+import {Session} from '$lib'
+
+import {makeClient} from '$test/utils/mock-client'
+import {mockSessionOptions} from './mock-session'
+import {makeMockAction, makeMockActions, makeMockTransaction} from '$test/utils/mock-transfer'
+
+const client = makeClient()
+
+export async function mockData(memo?: string) {
+    const info = await client.v1.chain.get_info()
+    const action = await makeMockAction(memo)
+    const actions = await makeMockActions(memo)
+    const transaction = await makeMockTransaction(info, memo)
+    const session = new Session(mockSessionOptions)
+    return {
+        action,
+        actions,
+        info,
+        session,
+        transaction,
+    }
+}

--- a/test/utils/mock-session.ts
+++ b/test/utils/mock-session.ts
@@ -1,0 +1,20 @@
+import {PermissionLevel} from '@greymass/eosio'
+
+import {ChainDefinition, SessionOptions} from '$lib'
+
+import {mockPermissionLevel} from '$test/utils/mock-config'
+import {mockFetch} from '$test/utils/mock-fetch'
+import {makeWallet} from '$test/utils/mock-wallet'
+
+const wallet = makeWallet()
+
+export const mockSessionOptions: SessionOptions = {
+    broadcast: false, // Disable broadcasting by default for tests, enable when required.
+    chain: ChainDefinition.from({
+        id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+        url: 'https://jungle4.greymass.com',
+    }),
+    fetch: mockFetch, // Required for unit tests
+    permissionLevel: PermissionLevel.from(mockPermissionLevel),
+    walletPlugin: wallet,
+}

--- a/test/utils/mock-transfer.ts
+++ b/test/utils/mock-transfer.ts
@@ -1,4 +1,5 @@
 import {Action, API, Asset, Name, Struct, Transaction} from '@greymass/eosio'
+
 import {mockAccountName, mockPermissionName} from './mock-config'
 
 @Struct.type('transfer')


### PR DESCRIPTION
I'm beginning by just adding helper functions into this `utils.ts` file. Once enough use cases and functions are built up, we can begin migrating these to the @greymass/eosio-signing-request library.