### PR TITLE
Split arguments and options for Session constructor

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -308,17 +308,22 @@ export class SessionKit {
         // TODO: Implement afterLogin hook
 
         // Create a session combining all this information
-        const session = new Session({
-            appName: this.appName,
-            chain: this.getChainDefinition(response.chain),
-            expireSeconds: this.expireSeconds,
-            fetch: this.fetch,
-            permissionLevel: response.permissionLevel,
-            transactPlugins: options?.transactPlugins || this.transactPlugins,
-            transactPluginsOptions: options?.transactPluginsOptions || this.transactPluginsOptions,
-            ui: this.ui,
-            walletPlugin: this.walletPlugins[0],
-        })
+        const session = new Session(
+            {
+                chain: this.getChainDefinition(response.chain),
+                permissionLevel: response.permissionLevel,
+                walletPlugin: this.walletPlugins[0],
+            },
+            {
+                appName: this.appName,
+                expireSeconds: this.expireSeconds,
+                fetch: this.fetch,
+                transactPlugins: options?.transactPlugins || this.transactPlugins,
+                transactPluginsOptions:
+                    options?.transactPluginsOptions || this.transactPluginsOptions,
+                ui: this.ui,
+            }
+        )
 
         // Notify the UI that the login request has completed.
         this.ui.onLoginResult()

--- a/test/tests/plugins/transact/resource-provider.ts
+++ b/test/tests/plugins/transact/resource-provider.ts
@@ -1,12 +1,11 @@
 import {assert} from 'chai'
-import zlib from 'pako'
 
-import {ABIDef, Action, Asset, AssetType, Name, Signature, Struct} from '@greymass/eosio'
+import {Action, Asset, AssetType, Name, Signature, Struct} from '@greymass/eosio'
 
 import {
-    AbiProvider,
     AbstractTransactPlugin,
     Session,
+    SessionArgs,
     SessionOptions,
     SigningRequest,
     TransactContext,
@@ -16,7 +15,6 @@ import {
 
 import {mockChainId, mockUrl} from '$test/utils/mock-config'
 import {mockFetch} from '$test/utils/mock-fetch'
-import {makeMockAction} from '$test/utils/mock-transfer'
 import {makeWallet} from '$test/utils/mock-wallet'
 
 const wallet = makeWallet()
@@ -96,7 +94,7 @@ export class MockTransactResourceProviderPlugin extends AbstractTransactPlugin {
 
         // TODO: Interact with interface for fee based prompting
 
-        /* Psuedo-code for fee based prompting
+        /* Pseudo-code for fee based prompting
 
         if (response.status === 402) {
 
@@ -185,19 +183,18 @@ const mockResourceProviderPlugin = new MockTransactResourceProviderPlugin({
     url: 'https://jungle4.greymass.com/v1/resource_provider/request_transaction',
 })
 
-const mockSessionOptions: SessionOptions = {
+const mockSessionArgs: SessionArgs = {
     chain: {
         id: mockChainId,
         url: mockUrl,
     },
-    /**
-     * NOT required for normal usage of wharfkit/session
-     * This is only required to execute sucessfully in a unit test environment.
-     */
-    fetch: mockFetch,
     permissionLevel: 'wharfkit1131@test',
-    transactPlugins: [mockResourceProviderPlugin],
     walletPlugin: wallet,
+}
+
+const mockSessionOptions: SessionOptions = {
+    fetch: mockFetch, // Required for unit tests
+    transactPlugins: [mockResourceProviderPlugin],
 }
 
 @Struct.type('transfer')
@@ -212,7 +209,7 @@ export const resourceProviderPlugin = () => {
     suite('resource provider', function () {
         test('provides free transaction', async function () {
             this.slow(10000)
-            const session = new Session(mockSessionOptions)
+            const session = new Session(mockSessionArgs, mockSessionOptions)
             const action = {
                 authorization: [
                     {

--- a/test/tests/transact.ts
+++ b/test/tests/transact.ts
@@ -1,14 +1,13 @@
 import {assert} from 'chai'
 import zlib from 'pako'
 
-import {Action, Name, PermissionLevel, Serializer, Signature, TimePointSec} from '@greymass/eosio'
+import {PermissionLevel, Serializer, Signature, TimePointSec} from '@greymass/eosio'
 import {ResolvedSigningRequest, SigningRequest} from 'eosio-signing-request'
 
 import SessionKit, {
     ABICache,
     ChainDefinition,
     Session,
-    SessionOptions,
     TransactContext,
     TransactHookTypes,
 } from '$lib'
@@ -25,27 +24,17 @@ import {makeMockAction, makeMockActions, makeMockTransaction} from '$test/utils/
 import {makeWallet} from '$test/utils/mock-wallet'
 import {mockPermissionLevel} from '$test/utils/mock-config'
 import {Transfer} from '$test/utils/setup/structs'
+import {mockSessionArgs, mockSessionOptions} from '$test/utils/mock-session'
 
 const client = makeClient()
 const wallet = makeWallet()
-
-const mockSessionOptions: SessionOptions = {
-    broadcast: false, // Disable broadcasting by default for tests, enable when required.
-    chain: ChainDefinition.from({
-        id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
-        url: 'https://jungle4.greymass.com',
-    }),
-    fetch: mockFetch, // Required for unit tests
-    permissionLevel: PermissionLevel.from(mockPermissionLevel),
-    walletPlugin: wallet,
-}
 
 async function mockData() {
     const info = await client.v1.chain.get_info()
     const action = await makeMockAction()
     const actions = await makeMockActions()
     const transaction = await makeMockTransaction(info)
-    const session = new Session(mockSessionOptions)
+    const session = new Session(mockSessionArgs, mockSessionOptions)
     return {
         action,
         actions,
@@ -252,14 +241,8 @@ suite('transact', function () {
         suite('broadcast', function () {
             test('default: true', async function () {
                 const {action} = await mockData()
-                const session = new Session({
-                    chain: ChainDefinition.from({
-                        id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
-                        url: 'https://jungle4.greymass.com',
-                    }),
-                    fetch: mockFetch, // Required for unit tests
-                    permissionLevel: PermissionLevel.from(mockPermissionLevel),
-                    walletPlugin: wallet,
+                const session = new Session(mockSessionArgs, {
+                    fetch: mockSessionOptions.fetch,
                 })
                 const result = await session.transact({action})
                 assert.isDefined(result.response)
@@ -281,15 +264,7 @@ suite('transact', function () {
         suite('expireSeconds', function () {
             test('default: 120', async function () {
                 const {action} = await mockData()
-                const session = new Session({
-                    chain: ChainDefinition.from({
-                        id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
-                        url: 'https://jungle4.greymass.com',
-                    }),
-                    fetch: mockFetch, // Required for unit tests
-                    permissionLevel: PermissionLevel.from(mockPermissionLevel),
-                    walletPlugin: wallet,
-                })
+                const session = new Session(mockSessionArgs, mockSessionOptions)
                 const result = await session.transact({action}, {broadcast: false})
                 // Get the chain info to get the current head block time from test cache
                 const {head_block_time} = await session.client.v1.chain.get_info()
@@ -301,15 +276,7 @@ suite('transact', function () {
             })
             test('override: 60', async function () {
                 const {action} = await mockData()
-                const session = new Session({
-                    chain: ChainDefinition.from({
-                        id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
-                        url: 'https://jungle4.greymass.com',
-                    }),
-                    fetch: mockFetch, // Required for unit tests
-                    permissionLevel: PermissionLevel.from(mockPermissionLevel),
-                    walletPlugin: wallet,
-                })
+                const session = new Session(mockSessionArgs, mockSessionOptions)
                 const expireSeconds = 60
                 const result = await session.transact({action}, {broadcast: false, expireSeconds})
                 // Get the chain info to get the current head block time from test cache
@@ -324,7 +291,7 @@ suite('transact', function () {
         suite('transactPlugins', function () {
             test('inherit', async function () {
                 const {action} = await mockData()
-                const session = new Session({
+                const session = new Session(mockSessionArgs, {
                     ...mockSessionOptions,
                     transactPlugins: [new MockTransactResourceProviderPlugin()],
                 })
@@ -391,7 +358,7 @@ suite('transact', function () {
         suite('transactPluginsOptions', function () {
             test('transact', async function () {
                 const {action} = await mockData()
-                const session = new Session({
+                const session = new Session(mockSessionArgs, {
                     ...mockSessionOptions,
                     transactPlugins: [new MockTransactResourceProviderPlugin()],
                 })
@@ -412,7 +379,7 @@ suite('transact', function () {
             })
             test('session constructor', async function () {
                 const {action} = await mockData()
-                const session = new Session({
+                const session = new Session(mockSessionArgs, {
                     ...mockSessionOptions,
                     transactPluginsOptions: {
                         disableExamplePlugin: true,
@@ -601,7 +568,7 @@ suite('transact', function () {
             const result = await session.transact({action})
             const transaction = result.resolved?.transaction
             if (transaction) {
-                const digest = transaction.signingDigest(mockSessionOptions.chain.id)
+                const digest = transaction.signingDigest(mockSessionArgs.chain.id)
                 const [signature] = result.signatures
                 const publicKey = signature.recoverDigest(digest)
                 assert.isTrue(publicKey.equals(wallet.privateKey.toPublic()))

--- a/test/tests/use-cases/general/nodejs.ts
+++ b/test/tests/use-cases/general/nodejs.ts
@@ -24,12 +24,12 @@ import {
 import {mockFetch} from '$test/utils/mock-fetch'
 
 /**
- * Required configuration for manually establishing a session.
+ * Required arguments for manually establishing a session.
  *
  * This session utilizes the WalletPluginPrivateKey plugin to sign transactions without
  * the need for an external wallet.
  */
-const sessionOptions = {
+const sessionArgs = {
     chain: {
         id: mockChainId,
         url: mockUrl,
@@ -38,6 +38,12 @@ const sessionOptions = {
     walletPlugin: new WalletPluginPrivateKey({
         privateKey: mockPrivateKey,
     }),
+}
+
+/**
+ * Optional arguments for manually establishing a session.
+ */
+const sessionOptions = {
     /**
      * NOT required for normal usage of wharfkit/session
      * This is only required to execute sucessfully in a unit test environment.
@@ -51,7 +57,7 @@ export const nodejsUsage = () => {
             // Ensure the test runs regardless of how slow the requests are
             this.slow(10000)
             // Establish a new session
-            const session = new Session(sessionOptions)
+            const session = new Session(sessionArgs, sessionOptions)
             // Perform a transaction
             const response = await session.transact({
                 action: {

--- a/test/utils/mock-data.ts
+++ b/test/utils/mock-data.ts
@@ -1,7 +1,7 @@
 import {Session} from '$lib'
 
 import {makeClient} from '$test/utils/mock-client'
-import {mockSessionOptions} from './mock-session'
+import {mockSessionArgs, mockSessionOptions} from './mock-session'
 import {makeMockAction, makeMockActions, makeMockTransaction} from '$test/utils/mock-transfer'
 
 const client = makeClient()
@@ -11,7 +11,7 @@ export async function mockData(memo?: string) {
     const action = await makeMockAction(memo)
     const actions = await makeMockActions(memo)
     const transaction = await makeMockTransaction(info, memo)
-    const session = new Session(mockSessionOptions)
+    const session = new Session(mockSessionArgs, mockSessionOptions)
     return {
         action,
         actions,

--- a/test/utils/mock-session.ts
+++ b/test/utils/mock-session.ts
@@ -1,6 +1,6 @@
 import {PermissionLevel} from '@greymass/eosio'
 
-import {ChainDefinition, SessionOptions} from '$lib'
+import {ChainDefinition, SessionArgs, SessionOptions} from '$lib'
 
 import {mockPermissionLevel} from '$test/utils/mock-config'
 import {mockFetch} from '$test/utils/mock-fetch'
@@ -8,13 +8,16 @@ import {makeWallet} from '$test/utils/mock-wallet'
 
 const wallet = makeWallet()
 
-export const mockSessionOptions: SessionOptions = {
-    broadcast: false, // Disable broadcasting by default for tests, enable when required.
+export const mockSessionArgs: SessionArgs = {
     chain: ChainDefinition.from({
         id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
         url: 'https://jungle4.greymass.com',
     }),
-    fetch: mockFetch, // Required for unit tests
     permissionLevel: PermissionLevel.from(mockPermissionLevel),
     walletPlugin: wallet,
+}
+
+export const mockSessionOptions: SessionOptions = {
+    broadcast: false, // Disable broadcasting by default for tests, enable when required.
+    fetch: mockFetch, // Required for unit tests
 }


### PR DESCRIPTION
This is a breaking change from 0.2.x to 0.3.x.

This change moves the required parameters into the SessionArgs as the first value of the constructor, and then moves all optional values as SessionOptions into the 2nd parameter of the constructor.

The goal is to make it easier to understand which values are required and which values are optional when manually creating a Session.