### PR TITLE
Add `arbitrary` parameter to LoginOptions

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -36,6 +36,7 @@ import {
 } from './account-creation'
 
 export interface LoginOptions {
+    arbitrary?: Record<string, any> // Arbitrary data that will be passed via context to wallet plugin
     chain?: ChainDefinition | Checksum256Type
     chains?: Checksum256Type[]
     loginPlugins?: LoginPlugin[]
@@ -327,6 +328,7 @@ export class SessionKit {
             // Create LoginContext for this login request.
             const context = new LoginContext({
                 appName: this.appName,
+                arbitrary: options?.arbitrary || {},
                 chain: undefined,
                 chains:
                     options && options?.chains

--- a/src/login.ts
+++ b/src/login.ts
@@ -23,6 +23,7 @@ export interface LoginHooks {
  */
 export interface LoginContextOptions {
     appName?: NameType
+    arbitrary?: Record<string, any>
     // client: APIClient
     chain?: ChainDefinition
     chains?: ChainDefinition[]
@@ -53,6 +54,7 @@ export interface UserInterfaceWalletPlugin {
  */
 export class LoginContext {
     appName?: string
+    arbitrary: Record<string, any> = {}
     // client: APIClient
     chain?: ChainDefinition
     chains: ChainDefinition[] = []
@@ -73,6 +75,9 @@ export class LoginContext {
     walletPlugins: UserInterfaceWalletPlugin[] = []
     constructor(options: LoginContextOptions) {
         this.appName = String(options.appName)
+        if (options.arbitrary) {
+            this.arbitrary = options.arbitrary
+        }
         // this.client = options.client
         if (options.chains) {
             this.chains = options.chains

--- a/test/tests/wallet.ts
+++ b/test/tests/wallet.ts
@@ -3,15 +3,13 @@ import {assert} from 'chai'
 import SessionKit, {
     ChainDefinition,
     LoginContext,
-    LoginOptions,
-    LoginResult,
     Logo,
     PermissionLevel,
     SessionKitArgs,
     SessionKitOptions,
     WalletPluginMetadata,
 } from '$lib'
-import {MockUserInterface, mockChainDefinition, mockPermissionLevel} from '@wharfkit/mock-data'
+import {mockChainDefinition, mockPermissionLevel, MockUserInterface} from '@wharfkit/mock-data'
 import {makeWallet, MockWalletPluginConfigs} from '@wharfkit/mock-data'
 import {mockFetch} from '@wharfkit/mock-data'
 import {makeMockAction} from '@wharfkit/mock-data'

--- a/test/tests/wallet.ts
+++ b/test/tests/wallet.ts
@@ -2,12 +2,16 @@ import {assert} from 'chai'
 
 import SessionKit, {
     ChainDefinition,
+    LoginContext,
+    LoginOptions,
+    LoginResult,
     Logo,
+    PermissionLevel,
     SessionKitArgs,
     SessionKitOptions,
     WalletPluginMetadata,
 } from '$lib'
-import {MockUserInterface} from '@wharfkit/mock-data'
+import {MockUserInterface, mockChainDefinition, mockPermissionLevel} from '@wharfkit/mock-data'
 import {makeWallet, MockWalletPluginConfigs} from '@wharfkit/mock-data'
 import {mockFetch} from '@wharfkit/mock-data'
 import {makeMockAction} from '@wharfkit/mock-data'
@@ -445,6 +449,34 @@ suite('walletPlugin', function () {
                 assert.equal(metadata.logo?.light, 'foo')
                 assert.equal(metadata.logo?.getVariant('dark'), 'bar')
                 assert.equal(metadata.logo?.dark, 'bar')
+            })
+        })
+    })
+    suite('arbitrary', function () {
+        test('nonce', async function () {
+            const walletPlugin = new MockWalletPluginConfigs()
+            walletPlugin.login = async function login(context: LoginContext) {
+                // Ensure the context.arbitrary field contains the values passed in from sessionKit.login
+                assert.equal(context.arbitrary.nonce, 'foo')
+                return {
+                    chain: context.chain
+                        ? context.chain.id
+                        : ChainDefinition.from(mockChainDefinition).id,
+                    permissionLevel:
+                        context.permissionLevel || PermissionLevel.from(mockPermissionLevel),
+                }
+            }
+            const kit = new SessionKit(
+                {
+                    ...defaultSessionKitArgs,
+                    walletPlugins: [walletPlugin],
+                },
+                defaultSessionKitOptions
+            )
+            await kit.login({
+                arbitrary: {
+                    nonce: 'foo',
+                },
             })
         })
     })


### PR DESCRIPTION
This data can be used (or ignored) by various wallet plugins as they process the login logic.