### PR TITLE
Add translations on login

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -27,7 +27,7 @@ import {
 } from './transact'
 import {WalletPlugin, WalletPluginLoginResponse, WalletPluginMetadata} from './wallet'
 import {UserInterface} from './ui'
-import {getFetch} from './utils'
+import {getFetch, getPluginTranslations} from './utils'
 import {
     AccountCreationPlugin,
     CreateAccountContext,
@@ -369,13 +369,13 @@ export class SessionKit {
                     context.uiRequirements.requiresWalletSelect = false
                 }
             }
-
             // Set any uiRequirement overrides from the wallet plugin
             if (walletPlugin) {
                 context.uiRequirements = {
                     ...context.uiRequirements,
                     ...walletPlugin.config,
                 }
+                context.ui.addTranslations(getPluginTranslations(walletPlugin))
             }
 
             // Predetermine chain (if possible) to prevent uneeded UI interactions.

--- a/src/session.ts
+++ b/src/session.ts
@@ -41,7 +41,7 @@ import {
     TransactRevisions,
 } from './transact'
 import {SessionStorage} from './storage'
-import {getFetch} from './utils'
+import {getFetch, getPluginTranslations} from './utils'
 import {SerializedWalletPlugin, WalletPlugin, WalletPluginSignResponse} from './wallet'
 import {UserInterface} from './ui'
 
@@ -426,7 +426,7 @@ export class Session {
                 await context.ui.onTransact()
                 // Merge in any new localization strings from the plugins
                 for (const translation of transactPlugins.map((transactPlugin) =>
-                    this.getPluginTranslations(transactPlugin)
+                    getPluginTranslations(transactPlugin)
                 )) {
                     context.ui.addTranslations(translation)
                 }
@@ -478,7 +478,7 @@ export class Session {
             // Merge in any new localization strings from the wallet plugin
             if (context.ui) {
                 await context.ui.onSign()
-                context.ui.addTranslations(this.getPluginTranslations(this.walletPlugin))
+                context.ui.addTranslations(getPluginTranslations(this.walletPlugin))
             }
 
             // Retrieve the signature(s) and request modifications for this request from the WalletPlugin
@@ -634,20 +634,6 @@ export class Session {
         }
 
         return Serializer.objectify(serializableData)
-    }
-
-    getPluginTranslations(transactPlugin: TransactPlugin | WalletPlugin): LocaleDefinitions {
-        if (!transactPlugin.translations) {
-            return {}
-        }
-        const prefixed = {}
-        const languages = Object.keys(transactPlugin.translations)
-        languages.forEach((lang) => {
-            if (transactPlugin.translations) {
-                prefixed[lang] = {[transactPlugin.id]: transactPlugin.translations[lang]}
-            }
-        })
-        return prefixed
     }
 
     getMergedAbiCache(args: TransactArgs, options?: TransactOptions): ABICacheInterface {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import {Action, AnyAction, FetchProviderOptions, Transaction} from '@wharfkit/antelope'
-import type {Fetch} from '@wharfkit/common'
+import type {Fetch, LocaleDefinitions} from '@wharfkit/common'
 import {SigningRequest} from '@wharfkit/signing-request'
+import {TransactPlugin} from './transact'
+import {WalletPlugin} from './wallet'
 
 /**
  * Return an instance of fetch.
@@ -90,4 +92,20 @@ export function prependAction(request: SigningRequest, action: AnyAction): Signi
         }
     }
     return cloned
+}
+
+export function getPluginTranslations(
+    transactPlugin: TransactPlugin | WalletPlugin
+): LocaleDefinitions {
+    if (!transactPlugin.translations) {
+        return {}
+    }
+    const prefixed = {}
+    const languages = Object.keys(transactPlugin.translations)
+    languages.forEach((lang) => {
+        if (transactPlugin.translations) {
+            prefixed[lang] = {[transactPlugin.id]: transactPlugin.translations[lang]}
+        }
+    })
+    return prefixed
 }


### PR DESCRIPTION
In SessionKit#login, the context.ui.addTranslations method is not called, so the translations in the plugin are not imported, resulting in the default English always being used.