### PR TITLE
SessionKit restore refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/session",
     "description": "Create account-based sessions, perform transactions, and allow users to login using Antelope-based blockchains.",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "homepage": "https://github.com/wharfkit/session",
     "license": "BSD-3-Clause",
     "main": "lib/session.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/session",
     "description": "Create account-based sessions, perform transactions, and allow users to login using Antelope-based blockchains.",
-    "version": "1.7.0",
+    "version": "1.7.1-beta1",
     "homepage": "https://github.com/wharfkit/session",
     "license": "BSD-3-Clause",
     "main": "lib/session.js",

--- a/src/encoded.ts
+++ b/src/encoded.ts
@@ -1,0 +1,35 @@
+import {Checksum256, Name, Struct} from '@wharfkit/antelope'
+import {RestoreArgs, SerializedSession, Session} from './index-module'
+
+/**
+ * The metadata of an [[AccountCreationPlugin]].
+ */
+@Struct.type('url_encoded_session')
+export class URLEncodedSession extends Struct {
+    @Struct.field(Checksum256) declare chain: Checksum256
+    @Struct.field(Name) declare actor: Name
+    @Struct.field(Name) declare permission: Name
+    @Struct.field('string') declare walletPlugin: string
+    @Struct.field('string', {optional: true}) declare data?: string
+
+    static fromSession(data: Session | SerializedSession): URLEncodedSession {
+        const session = data instanceof Session ? data.serialize() : data
+        return new URLEncodedSession({
+            chain: session.chain,
+            actor: session.actor,
+            permission: session.permission,
+            walletPlugin: JSON.stringify(session.walletPlugin),
+            data: JSON.stringify(session.data),
+        })
+    }
+
+    get args(): RestoreArgs {
+        return {
+            chain: this.chain,
+            actor: this.actor,
+            permission: this.permission,
+            walletPlugin: JSON.parse(this.walletPlugin),
+            data: this.data ? JSON.parse(this.data) : undefined,
+        }
+    }
+}

--- a/src/encoded.ts
+++ b/src/encoded.ts
@@ -1,5 +1,5 @@
 import {Checksum256, Name, Struct} from '@wharfkit/antelope'
-import {RestoreArgs, SerializedSession, Session} from './index-module'
+import {SerializedSession, Session} from './index-module'
 
 /**
  * The metadata of an [[AccountCreationPlugin]].
@@ -23,7 +23,7 @@ export class URLEncodedSession extends Struct {
         })
     }
 
-    get args(): RestoreArgs {
+    get serialized(): SerializedSession {
         return {
             chain: this.chain,
             actor: this.actor,

--- a/src/index-module.ts
+++ b/src/index-module.ts
@@ -1,3 +1,4 @@
+export * from './encoded'
 export * from './kit'
 export * from './login'
 export * from './session'

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -768,7 +768,7 @@ export class SessionKit {
                 })
                 // Remove the default status from all other sessions for this chain
                 .map((s: SerializedSession): SerializedSession => {
-                    if (session.chain.id.equals(s.chain)) {
+                    if (setAsDefault && session.chain.id.equals(s.chain)) {
                         s.default = false
                     }
                     return s

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -800,12 +800,7 @@ export class SessionKit {
         try {
             const parsed = JSON.parse(data)
             // Only return sessions that have a wallet plugin that is currently registered.
-            const filtered = parsed.filter((s: SerializedSession) =>
-                this.walletPlugins.some((p) => {
-                    return p.id === s.walletPlugin.id
-                })
-            )
-            return filtered
+            return getSessionsMatchingWalletPlugins(parsed, this.walletPlugins)
         } catch (e) {
             throw new Error(`Failed to parse sessions from storage (${e})`)
         }
@@ -824,4 +819,11 @@ export class SessionKit {
             ui: this.ui,
         }
     }
+}
+
+export function getSessionsMatchingWalletPlugins(
+    sessions: SerializedSession[],
+    walletPlugins: WalletPlugin[]
+) {
+    return sessions.filter((s) => walletPlugins.some((p) => p.id === s.walletPlugin.id))
 }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -18,7 +18,7 @@ import {
     LoginPlugin,
     UserInterfaceWalletPlugin,
 } from './login'
-import {SerializedSession, Session} from './session'
+import {PartialSerializedSession, SerializedSession, Session} from './session'
 import {BrowserLocalStorage, SessionStorage} from './storage'
 import {
     AbstractTransactPlugin,
@@ -42,12 +42,17 @@ export interface LoginOptions {
     arbitrary?: Record<string, any> // Arbitrary data that will be passed via context to wallet plugin
     chain?: ChainDefinition | Checksum256Type
     chains?: Checksum256Type[]
+    equalityFn?: SerializedSessionEqualityFn
     loginPlugins?: LoginPlugin[]
     setAsDefault?: boolean
     transactPlugins?: TransactPlugin[]
     transactPluginsOptions?: TransactPluginsOptions
     permissionLevel?: PermissionLevelType | string
     walletPlugin?: string
+}
+
+export interface LogoutOptions {
+    equalityFn?: SerializedSessionEqualityFn
 }
 
 export interface LoginResult {
@@ -61,12 +66,13 @@ export interface LogoutContext {
     appName: string
 }
 
-export interface RestoreArgs {
-    chain: Checksum256Type | ChainDefinition
-    actor?: NameType
-    permission?: NameType
-    walletPlugin?: Record<string, any>
-    data?: Record<string, any>
+export type SessionType = Session | SerializedSession
+
+export type SerializedSessionEqualityFn = (a: SessionType, b: SessionType) => boolean
+
+export interface PersistOptions {
+    setAsDefault?: boolean
+    equalityFn?: SerializedSessionEqualityFn
 }
 
 export interface SessionKitArgs {
@@ -83,6 +89,7 @@ export interface SessionKitOptions {
     accountCreationPlugins?: AccountCreationPlugin[]
     allowModify?: boolean
     contracts?: Contract[]
+    equalityFn?: SerializedSessionEqualityFn
     expireSeconds?: number
     fetch?: Fetch
     loginPlugins?: LoginPlugin[]
@@ -101,6 +108,7 @@ export class SessionKit {
     readonly accountCreationPlugins: AccountCreationPlugin[] = []
     readonly allowModify: boolean = true
     readonly appName: string
+    readonly equalityFn: SerializedSessionEqualityFn = serializedSessionEquals
     readonly expireSeconds: number = 120
     readonly fetch: Fetch
     readonly loginPlugins: AbstractLoginPlugin[]
@@ -141,6 +149,10 @@ export class SessionKit {
         // Extract any ABIs from the Contract instances provided
         if (options.contracts) {
             this.abis.push(...options.contracts.map((c) => ({account: c.account, abi: c.abi})))
+        }
+        // Override equality function if provided
+        if (options.equalityFn) {
+            this.equalityFn = options.equalityFn
         }
         // Establish default plugins for login flow
         if (options.loginPlugins) {
@@ -200,6 +212,14 @@ export class SessionKit {
             throw new Error(`No chain defined with an ID of: ${chainId}`)
         }
         return chain
+    }
+
+    getWalletPlugin(id: string): WalletPlugin {
+        const walletPlugin = this.walletPlugins.find((p) => p.id === id)
+        if (!walletPlugin) {
+            throw new Error(`No WalletPlugin found with the ID of: '${id}'`)
+        }
+        return walletPlugin
     }
 
     /**
@@ -489,7 +509,9 @@ export class SessionKit {
             for (const hook of context.hooks.afterLogin) await hook(context)
 
             // Save the session to storage if it has a storage instance.
-            this.persistSession(session, options?.setAsDefault)
+            this.persistSession(session, {
+                setAsDefault: options?.setAsDefault,
+            })
 
             // Notify the UI that the login request has completed.
             await context.ui.onLoginComplete()
@@ -527,7 +549,7 @@ export class SessionKit {
         }
     }
 
-    async logout(session?: Session | SerializedSession) {
+    async logout(session?: Session | SerializedSession, options: LogoutOptions = {}) {
         if (!this.storage) {
             throw new Error('An instance of Storage must be provided to utilize the logout method.')
         }
@@ -543,17 +565,8 @@ export class SessionKit {
 
             const sessions = await this.getSessions()
             if (sessions) {
-                let serialized = session
-                if (session instanceof Session) {
-                    serialized = session.serialize()
-                }
-                const other = sessions.filter((s: Record<string, any>) => {
-                    return (
-                        !Checksum256.from(s.chain).equals(String(serialized.chain)) ||
-                        !Name.from(s.actor).equals(serialized.actor) ||
-                        !Name.from(s.permission).equals(serialized.permission)
-                    )
-                })
+                const equalityFn = options.equalityFn || this.equalityFn
+                const other = sessions.filter((s) => !equalityFn(s, session))
                 await this.storage.write('sessions', JSON.stringify(other))
             }
         } else {
@@ -579,121 +592,73 @@ export class SessionKit {
         }
     }
 
-    async restore(args?: RestoreArgs, options?: LoginOptions): Promise<Session | undefined> {
-        if (!args) {
-            if (this.acceptUrlSession && typeof window !== 'undefined') {
-                // Attempt to retrieve session from current URL params
-                const url = new URL(window.location.href)
-                const incoming = url.searchParams.get(this.acceptUrlSessionParam)
-                if (incoming) {
-                    try {
-                        const encodedSession = Serializer.decode({
-                            data: Bytes.from(incoming, 'hex'),
-                            type: URLEncodedSession,
-                        })
-                        args = encodedSession.args
-                        // Remove the session from the URL to prevent reuse
-                        url.searchParams.delete(this.acceptUrlSessionParam)
-                        window.history.replaceState(null, '', url)
-                    } catch (e) {
-                        // eslint-disable-next-line no-console -- warn the developer since this may be unintentional
-                        console.warn('Failed to decode session from URL: ' + incoming)
-                    }
-                }
-            }
-
-            // If no args were provided or retrieved from the URL, attempt to default restore the session from storage.
-            if (!args) {
-                const data = await this.storage.read('session')
-                if (!args && data) {
-                    args = JSON.parse(data)
-                } else {
-                    return
-                }
+    restoreFromURL(): SerializedSession | undefined {
+        // Attempt to retrieve session from current URL params
+        const url = new URL(window.location.href)
+        const urlSessionParam = url.searchParams.get(this.acceptUrlSessionParam)
+        if (urlSessionParam) {
+            try {
+                const encodedSession = Serializer.decode({
+                    data: Bytes.from(urlSessionParam, 'hex'),
+                    type: URLEncodedSession,
+                })
+                // Remove the session from the URL to prevent reuse
+                url.searchParams.delete(this.acceptUrlSessionParam)
+                window.history.replaceState(null, '', url)
+                // Return the serialized session
+                return encodedSession.serialized
+            } catch (e) {
+                // eslint-disable-next-line no-console -- warn the developer since this may be unintentional
+                console.warn('Failed to decode session from URL: ' + urlSessionParam)
             }
         }
+    }
 
-        if (!args) {
-            throw new Error('Either a RestoreArgs object or a Storage instance must be provided.')
-        }
-
-        const chainId = Checksum256.from(
-            args.chain instanceof ChainDefinition ? args.chain.id : args.chain
-        )
-
+    async restoreWithoutArgs(): Promise<SerializedSession | undefined> {
         let serializedSession: SerializedSession | undefined
 
-        // Retrieve all sessions from storage
-        const data = await this.storage.read('sessions')
-        if (data) {
-            // If sessions exist, restore the session that matches the provided args
-            const sessions = JSON.parse(data) as SerializedSession[]
-            if (args.actor && args.permission) {
-                // If all args are provided, return exact match
-                serializedSession = sessions.find((s: SerializedSession) => {
-                    return (
-                        args &&
-                        chainId.equals(s.chain) &&
-                        s.actor === args.actor &&
-                        s.permission === args.permission
-                    )
-                })
-            } else {
-                // If no actor/permission defined, return based on chain
-                serializedSession = sessions.find((s: SerializedSession) => {
-                    return args && chainId.equals(s.chain) && s.default
-                })
-            }
+        // Attempt to restore from URL (if enabled and in browser)
+        if (this.acceptUrlSession && typeof window !== 'undefined') {
+            serializedSession = this.restoreFromURL()
         }
 
-        // If no sessions were found, but the args contains all the data for a serialized session, use args
+        // If no session from from the URL, attempt to restore the session from storage
         if (!serializedSession) {
-            if (args.actor && args.permission && args.walletPlugin) {
-                serializedSession = {
-                    chain: String(chainId),
-                    actor: args.actor,
-                    permission: args.permission,
-                    walletPlugin: {
-                        id: args.walletPlugin.id,
-                        data: args.walletPlugin.data,
-                    },
-                    data: args.data,
-                }
-            } else {
-                // Otherwise throw an error since we can't establish the session data
-                throw new Error('No sessions found in storage. A wallet plugin must be provided.')
+            const data = await this.storage.read('session')
+            if (data) {
+                serializedSession = JSON.parse(data)
             }
         }
 
-        // If no session found, return
+        return serializedSession
+    }
+
+    async restoreWithArgs(args: PartialSerializedSession): Promise<SerializedSession | undefined> {
+        let serializedSession = upgradePossibleSerializedSession(args)
         if (!serializedSession) {
-            return
-        }
-
-        // Ensure a WalletPlugin was found with the provided ID.
-        const walletPlugin = this.walletPlugins.find((p) => {
-            if (!args) {
-                return false
+            const data = await this.storage.read('sessions')
+            if (data) {
+                const sessions = JSON.parse(data) as SerializedSession[]
+                serializedSession = sessions.find(
+                    (s) => Checksum256.from(args.chain).equals(s.chain) && s.default
+                )
             }
-            return p.id === serializedSession?.walletPlugin.id
-        })
-
-        if (!walletPlugin) {
-            throw new Error(
-                `No WalletPlugin found with the ID of: '${serializedSession.walletPlugin.id}'`
-            )
         }
+        return serializedSession
+    }
 
-        // Set the wallet data from the serialized session
+    getWalletPluginFromSerialized(serializedSession: SerializedSession): WalletPlugin {
+        const walletPlugin = this.getWalletPlugin(serializedSession.walletPlugin.id)
+
+        // Set the WalletPlugin data if it exists on the serialized session
         if (serializedSession.walletPlugin.data) {
             walletPlugin.data = serializedSession.walletPlugin.data
         }
 
-        // If walletPlugin data was provided by args, override
-        if (args.walletPlugin && args.walletPlugin.data) {
-            walletPlugin.data = args.walletPlugin.data
-        }
+        return walletPlugin
+    }
 
+    serializedToSession(serializedSession: SerializedSession, options: LoginOptions = {}): Session {
         // Create a new session from the provided args.
         const session = new Session(
             {
@@ -702,52 +667,63 @@ export class SessionKit {
                     actor: serializedSession.actor,
                     permission: serializedSession.permission,
                 }),
-                walletPlugin,
+                walletPlugin: this.getWalletPluginFromSerialized(serializedSession),
             },
             this.getSessionOptions(options)
         )
 
+        // Set the session data if it exists on the serialized session
         if (serializedSession.data) {
             session.data = serializedSession.data
         }
 
-        // Save the session to storage if it has a storage instance.
-        this.persistSession(session, options?.setAsDefault)
-
-        // Return the session
         return session
+    }
+
+    async restore(
+        args?: PartialSerializedSession,
+        options?: LoginOptions
+    ): Promise<Session | undefined> {
+        const serializedSession = args
+            ? await this.restoreWithArgs(args)
+            : await this.restoreWithoutArgs()
+
+        if (serializedSession) {
+            // Create a session from the serialized session data
+            const session = this.serializedToSession(serializedSession, options)
+
+            // Persist the session to storage
+            this.persistSession(session, {setAsDefault: options?.setAsDefault})
+
+            // Return the session
+            return session
+        }
     }
 
     async restoreAll(): Promise<Session[]> {
         const sessions: Session[] = []
         const serializedSessions = await this.getSessions()
-        if (serializedSessions) {
-            for (const s of serializedSessions) {
-                const session = await this.restore(s)
-                if (session) {
-                    sessions.push(session)
-                }
+        for (const serializedSession of serializedSessions) {
+            const session = await this.restore(serializedSession)
+            if (session) {
+                sessions.push(session)
             }
         }
         return sessions
     }
 
-    async persistSession(session: Session, setAsDefault = true) {
-        // TODO: Allow disabling of session persistence via kit options
-
-        // If no storage exists, do nothing.
-        if (!this.storage) {
-            return
-        }
-
+    async persistSession(session: Session, options: PersistOptions = {}) {
         // Serialize session passed in
         const serialized = session.serialize()
 
         // Specify whether or not this is now the default for the given chain
-        serialized.default = setAsDefault
+        serialized.default = options.setAsDefault !== undefined ? options.setAsDefault : true
 
-        // Set this as the current session for all chains
-        if (setAsDefault) {
+        // Determine equality function to use
+        const equalityFn = options.equalityFn || this.equalityFn
+
+        // If this session is the default, write it to the 'session' key for persistence
+        if (serialized.default) {
             this.storage.write('session', JSON.stringify(serialized))
         }
 
@@ -757,16 +733,10 @@ export class SessionKit {
             const stored = JSON.parse(existing)
             const sessions: SerializedSession[] = stored
                 // Filter out any matching session to ensure no duplicates
-                .filter((s: SerializedSession): boolean => {
-                    return (
-                        !Checksum256.from(s.chain).equals(serialized.chain) ||
-                        !Name.from(s.actor).equals(serialized.actor) ||
-                        !Name.from(s.permission).equals(serialized.permission)
-                    )
-                })
-                // Remove the default status from all other sessions for this chain
+                .filter((s) => !equalityFn(s, serialized))
+                // If the new session is the default, remove the default status from all other sessions for this chain
                 .map((s: SerializedSession): SerializedSession => {
-                    if (setAsDefault && session.chain.id.equals(s.chain)) {
+                    if (serialized.default && session.chain.id.equals(s.chain)) {
                         s.default = false
                     }
                     return s
@@ -824,4 +794,34 @@ export function getSessionsMatchingWalletPlugins(
     walletPlugins: WalletPlugin[]
 ) {
     return sessions.filter((s) => walletPlugins.some((p) => p.id === s.walletPlugin.id))
+}
+
+export function upgradePossibleSerializedSession(
+    possible: PartialSerializedSession | undefined
+): SerializedSession | undefined {
+    if (
+        possible &&
+        possible.actor !== undefined &&
+        possible.chain !== undefined &&
+        possible.permission !== undefined &&
+        possible.walletPlugin !== undefined
+    ) {
+        return {
+            actor: possible.actor,
+            chain: possible.chain,
+            permission: possible.permission,
+            walletPlugin: possible.walletPlugin,
+            data: possible.data,
+        }
+    }
+}
+
+export function serializedSessionEquals(a: SessionType, b: SessionType): boolean {
+    const first = a instanceof Session ? a.serialize() : a
+    const second = b instanceof Session ? b.serialize() : b
+    return (
+        Checksum256.from(first.chain).equals(second.chain) &&
+        Name.from(first.actor).equals(second.actor) &&
+        Name.from(first.permission).equals(second.permission)
+    )
 }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -549,11 +549,9 @@ export class SessionKit {
                 }
                 const other = sessions.filter((s: Record<string, any>) => {
                     return (
-                        !Checksum256.from(s.chain).equals(
-                            Checksum256.from(String(serialized.chain))
-                        ) ||
-                        !Name.from(s.actor).equals(Name.from(serialized.actor)) ||
-                        !Name.from(s.permission).equals(Name.from(serialized.permission))
+                        !Checksum256.from(s.chain).equals(String(serialized.chain)) ||
+                        !Name.from(s.actor).equals(serialized.actor) ||
+                        !Name.from(s.permission).equals(serialized.permission)
                     )
                 })
                 await this.storage.write('sessions', JSON.stringify(other))
@@ -761,9 +759,9 @@ export class SessionKit {
                 // Filter out any matching session to ensure no duplicates
                 .filter((s: SerializedSession): boolean => {
                     return (
-                        !Checksum256.from(s.chain).equals(Checksum256.from(serialized.chain)) ||
-                        !Name.from(s.actor).equals(Name.from(serialized.actor)) ||
-                        !Name.from(s.permission).equals(Name.from(serialized.permission))
+                        !Checksum256.from(s.chain).equals(serialized.chain) ||
+                        !Name.from(s.actor).equals(serialized.actor) ||
+                        !Name.from(s.permission).equals(serialized.permission)
                     )
                 })
                 // Remove the default status from all other sessions for this chain

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1,12 +1,14 @@
 import {ChainDefinition, type ChainDefinitionType, type Fetch} from '@wharfkit/common'
 import type {Contract} from '@wharfkit/contract'
 import {
+    Bytes,
     Checksum256,
     Checksum256Type,
     Name,
     NameType,
     PermissionLevel,
     PermissionLevelType,
+    Serializer,
 } from '@wharfkit/antelope'
 
 import {
@@ -34,6 +36,7 @@ import {
     CreateAccountOptions,
     CreateAccountResponse,
 } from './account-creation'
+import {URLEncodedSession} from './encoded'
 
 export interface LoginOptions {
     arbitrary?: Record<string, any> // Arbitrary data that will be passed via context to wallet plugin
@@ -75,6 +78,9 @@ export interface SessionKitArgs {
 
 export interface SessionKitOptions {
     abis?: TransactABIDef[]
+    acceptUrlSession?: boolean
+    acceptUrlSessionParam?: string
+    accountCreationPlugins?: AccountCreationPlugin[]
     allowModify?: boolean
     contracts?: Contract[]
     expireSeconds?: number
@@ -83,7 +89,6 @@ export interface SessionKitOptions {
     storage?: SessionStorage
     transactPlugins?: TransactPlugin[]
     transactPluginsOptions?: TransactPluginsOptions
-    accountCreationPlugins?: AccountCreationPlugin[]
 }
 
 /**
@@ -91,6 +96,9 @@ export interface SessionKitOptions {
  */
 export class SessionKit {
     readonly abis: TransactABIDef[] = []
+    readonly acceptUrlSession: boolean = false
+    readonly acceptUrlSessionParam: string = 'incomingWharfSession'
+    readonly accountCreationPlugins: AccountCreationPlugin[] = []
     readonly allowModify: boolean = true
     readonly appName: string
     readonly expireSeconds: number = 120
@@ -101,7 +109,6 @@ export class SessionKit {
     readonly transactPluginsOptions: TransactPluginsOptions = {}
     readonly ui: UserInterface
     readonly walletPlugins: WalletPlugin[]
-    readonly accountCreationPlugins: AccountCreationPlugin[] = []
     public chains: ChainDefinition[]
 
     constructor(args: SessionKitArgs, options: SessionKitOptions = {}) {
@@ -122,6 +129,14 @@ export class SessionKit {
         // Add any ABIs manually provided
         if (options.abis) {
             this.abis = [...options.abis]
+        }
+        // Determine if URL sessions should be accepted
+        if (options.acceptUrlSession) {
+            this.acceptUrlSession = options.acceptUrlSession
+        }
+        // Determine if URL session param name was overridden
+        if (options.acceptUrlSessionParam) {
+            this.acceptUrlSessionParam = options.acceptUrlSessionParam
         }
         // Extract any ABIs from the Contract instances provided
         if (options.contracts) {
@@ -567,13 +582,36 @@ export class SessionKit {
     }
 
     async restore(args?: RestoreArgs, options?: LoginOptions): Promise<Session | undefined> {
-        // If no args were provided, attempt to default restore the session from storage.
         if (!args) {
-            const data = await this.storage.read('session')
-            if (data) {
-                args = JSON.parse(data)
-            } else {
-                return
+            if (this.acceptUrlSession && typeof window !== 'undefined') {
+                // Attempt to retrieve session from current URL params
+                const url = new URL(window.location.href)
+                const incoming = url.searchParams.get(this.acceptUrlSessionParam)
+                if (incoming) {
+                    try {
+                        const encodedSession = Serializer.decode({
+                            data: Bytes.from(incoming, 'hex'),
+                            type: URLEncodedSession,
+                        })
+                        args = encodedSession.args
+                        // Remove the session from the URL to prevent reuse
+                        url.searchParams.delete(this.acceptUrlSessionParam)
+                        window.history.replaceState(null, '', url)
+                    } catch (e) {
+                        // eslint-disable-next-line no-console -- warn the developer since this may be unintentional
+                        console.warn('Failed to decode session from URL: ' + incoming)
+                    }
+                }
+            }
+
+            // If no args were provided or retrieved from the URL, attempt to default restore the session from storage.
+            if (!args) {
+                const data = await this.storage.read('session')
+                if (!args && data) {
+                    args = JSON.parse(data)
+                } else {
+                    return
+                }
             }
         }
 
@@ -585,14 +623,13 @@ export class SessionKit {
             args.chain instanceof ChainDefinition ? args.chain.id : args.chain
         )
 
-        let serializedSession: SerializedSession
+        let serializedSession: SerializedSession | undefined
 
         // Retrieve all sessions from storage
         const data = await this.storage.read('sessions')
-
         if (data) {
             // If sessions exist, restore the session that matches the provided args
-            const sessions = JSON.parse(data)
+            const sessions = JSON.parse(data) as SerializedSession[]
             if (args.actor && args.permission) {
                 // If all args are provided, return exact match
                 serializedSession = sessions.find((s: SerializedSession) => {
@@ -609,8 +646,10 @@ export class SessionKit {
                     return args && chainId.equals(s.chain) && s.default
                 })
             }
-        } else {
-            // If no sessions were found, but the args contains all the data for a serialized session, use args
+        }
+
+        // If no sessions were found, but the args contains all the data for a serialized session, use args
+        if (!serializedSession) {
             if (args.actor && args.permission && args.walletPlugin) {
                 serializedSession = {
                     chain: String(chainId),
@@ -638,7 +677,7 @@ export class SessionKit {
             if (!args) {
                 return false
             }
-            return p.id === serializedSession.walletPlugin.id
+            return p.id === serializedSession?.walletPlugin.id
         })
 
         if (!walletPlugin) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -85,6 +85,15 @@ export interface SerializedSession {
     data?: Record<string, any>
 }
 
+export interface PartialSerializedSession extends Partial<SerializedSession> {
+    actor?: NameType
+    chain: Checksum256Type
+    default?: boolean
+    permission?: NameType
+    walletPlugin?: SerializedWalletPlugin
+    data?: Record<string, any>
+}
+
 export type SessionEncodingTypes = 'encoded' | 'json' | 'serialized' | 'url'
 
 /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -44,6 +44,7 @@ import {SessionStorage} from './storage'
 import {getFetch, getPluginTranslations} from './utils'
 import {SerializedWalletPlugin, WalletPlugin, WalletPluginSignResponse} from './wallet'
 import {UserInterface} from './ui'
+import {URLEncodedSession} from './encoded'
 
 /**
  * Arguments required to create a new [[Session]].
@@ -51,6 +52,7 @@ import {UserInterface} from './ui'
 export interface SessionArgs {
     actor?: NameType
     chain: ChainDefinitionType
+    data?: Record<string, any>
     permission?: NameType
     permissionLevel?: PermissionLevelType | string
     walletPlugin: WalletPlugin
@@ -82,6 +84,8 @@ export interface SerializedSession {
     walletPlugin: SerializedWalletPlugin
     data?: Record<string, any>
 }
+
+export type SessionEncodingTypes = 'encoded' | 'json' | 'serialized' | 'url'
 
 /**
  * A representation of a session to interact with a specific blockchain account.
@@ -139,6 +143,11 @@ export class Session {
 
         // Set the WalletPlugin for this session
         this.walletPlugin = args.walletPlugin
+
+        // Initialize any arbitrary data provided to the constructor
+        if (args.data) {
+            this.data = args.data
+        }
 
         // Handle all the optional values provided
         if (options.appName) {
@@ -681,6 +690,30 @@ export class Session {
         }
 
         return abiCache
+    }
+
+    encode(encoding: 'encoded'): URLEncodedSession
+    encode(encoding: 'json'): string
+    encode(encoding: 'serialized'): SerializedSession
+    encode(encoding: 'url'): string
+    encode(
+        encoding: SessionEncodingTypes = 'serialized'
+    ): string | SerializedSession | URLEncodedSession {
+        const serialized = this.serialize()
+        switch (encoding) {
+            case 'encoded':
+                return URLEncodedSession.fromSession(serialized)
+            case 'json':
+                return JSON.stringify(serialized)
+            case 'serialized':
+                return serialized
+            case 'url':
+                return Serializer.encode({
+                    object: URLEncodedSession.fromSession(serialized),
+                }).toString('hex')
+            default:
+                throw new Error(`Unsupported encoding: ${encoding}`)
+        }
     }
 }
 

--- a/test/tests/kit.ts
+++ b/test/tests/kit.ts
@@ -616,6 +616,80 @@ suite('kit', function () {
             assert.isTrue(sessions[2].actor.equals('mock3'))
         })
     })
+    suite('persistSession', function () {
+        test('persists session data', async function () {
+            const sessionKit = new SessionKit(mockSessionKitArgs, {
+                ...mockSessionKitOptions,
+                storage: new MockStorage(),
+            })
+            const {session} = await sessionKit.login()
+            await sessionKit.persistSession(session)
+            const restored = await sessionKit.restore()
+            if (!restored) {
+                throw new Error('Failed to restore session')
+            }
+            assert.deepEqual(restored.serialize(), session.serialize())
+        })
+        test('prevent duplicates', async function () {
+            const sessionKit = new SessionKit(mockSessionKitArgs, {
+                ...mockSessionKitOptions,
+                storage: new MockStorage(),
+            })
+            const {session} = await sessionKit.login()
+            await sessionKit.persistSession(session)
+            await sessionKit.persistSession(session)
+            const sessions = await sessionKit.getSessions()
+            assert.lengthOf(sessions, 1)
+        })
+        test('sets default on new session', async function () {
+            const sessionKit = new SessionKit(mockSessionKitArgs, {
+                ...mockSessionKitOptions,
+                storage: new MockStorage(),
+            })
+            const session1 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session1)
+            const session2 = new Session({
+                actor: 'session2',
+                permission: 'test',
+                chain: mockChainDefinition,
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session2)
+            const sessions = await sessionKit.getSessions()
+            assert.lengthOf(sessions, 2)
+            assert.equal(sessions[0].default, false)
+            assert.equal(sessions[1].default, true)
+        })
+        test('prevent default on new session', async function () {
+            const sessionKit = new SessionKit(mockSessionKitArgs, {
+                ...mockSessionKitOptions,
+                storage: new MockStorage(),
+            })
+            const session1 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session1)
+            const session2 = new Session({
+                actor: 'session2',
+                permission: 'test',
+                chain: mockChainDefinition,
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session2, false)
+            const sessions = await sessionKit.getSessions()
+            assert.lengthOf(sessions, 2)
+            assert.equal(sessions[0].default, true)
+            assert.equal(sessions[1].default, false)
+        })
+    })
     suite('setEndpoint', function () {
         test('able to change api endpoint', async function () {
             // Start with a Session

--- a/test/tests/kit.ts
+++ b/test/tests/kit.ts
@@ -15,7 +15,7 @@ import {
     UserInterfaceLoginResponse,
 } from '$lib'
 
-import {makeWallet, MockWalletPluginConfigs} from '@wharfkit/mock-data'
+import {makeWallet, mockSessionOptions, MockWalletPluginConfigs} from '@wharfkit/mock-data'
 import {MockTransactPlugin} from '@wharfkit/mock-data'
 import {makeMockAction} from '@wharfkit/mock-data'
 import {
@@ -337,28 +337,37 @@ suite('kit', function () {
             assert.lengthOf(sessionsAfterLogout, 0)
         })
         test('session param', async function () {
-            const session1 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                walletPlugin: makeWallet(),
-            })
+            const session1 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    walletPlugin: makeWallet(),
+                },
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session1)
 
-            const session2 = new Session({
-                actor: 'session2',
-                permission: 'test',
-                chain: mockChainDefinition,
-                walletPlugin: makeWallet(),
-            })
+            const session2 = new Session(
+                {
+                    actor: 'session2',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    walletPlugin: makeWallet(),
+                },
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session2)
 
-            const session3 = new Session({
-                actor: 'session3',
-                permission: 'test',
-                chain: Chains.EOS,
-                walletPlugin: makeWallet(),
-            })
+            const session3 = new Session(
+                {
+                    actor: 'session3',
+                    permission: 'test',
+                    chain: Chains.EOS,
+                    walletPlugin: makeWallet(),
+                },
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session3)
 
             const sessionsBeforeLogout = await sessionKit.getSessions()
@@ -682,19 +691,25 @@ suite('kit', function () {
                 ...mockSessionKitOptions,
                 storage: new MockStorage(),
             })
-            const session1 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                walletPlugin: makeWallet(),
-            })
+            const session1 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    walletPlugin: makeWallet(),
+                },
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session1)
-            const session2 = new Session({
-                actor: 'session2',
-                permission: 'test',
-                chain: mockChainDefinition,
-                walletPlugin: makeWallet(),
-            })
+            const session2 = new Session(
+                {
+                    actor: 'session2',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    walletPlugin: makeWallet(),
+                },
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session2)
             const sessions = await sessionKit.getSessions()
             assert.lengthOf(sessions, 2)
@@ -706,19 +721,25 @@ suite('kit', function () {
                 ...mockSessionKitOptions,
                 storage: new MockStorage(),
             })
-            const session1 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                walletPlugin: makeWallet(),
-            })
+            const session1 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    walletPlugin: makeWallet(),
+                },
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session1)
-            const session2 = new Session({
-                actor: 'session2',
-                permission: 'test',
-                chain: mockChainDefinition,
-                walletPlugin: makeWallet(),
-            })
+            const session2 = new Session(
+                {
+                    actor: 'session2',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    walletPlugin: makeWallet(),
+                },
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session2, {setAsDefault: false})
             const sessions = await sessionKit.getSessions()
             assert.lengthOf(sessions, 2)
@@ -734,25 +755,31 @@ suite('kit', function () {
                 storage: new MockStorage(),
             })
             // Create two sessions for the same chain, actor, and permission but different appIds
-            const session1 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                data: {
-                    appId: 'app1',
+            const session1 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    data: {
+                        appId: 'app1',
+                    },
+                    walletPlugin: makeWallet(),
                 },
-                walletPlugin: makeWallet(),
-            })
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session1)
-            const session2 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                data: {
-                    appId: 'app2',
+            const session2 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    data: {
+                        appId: 'app2',
+                    },
+                    walletPlugin: makeWallet(),
                 },
-                walletPlugin: makeWallet(),
-            })
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session2)
             const sessions = await sessionKit.getSessions()
             // The base rules prevent duplicate sessions based on chain, actor, and permission only
@@ -780,25 +807,31 @@ suite('kit', function () {
                 storage: new MockStorage(),
             })
             // Create two sessions for the same user with different appIds
-            const session1 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                data: {
-                    appId: 'app1',
+            const session1 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    data: {
+                        appId: 'app1',
+                    },
+                    walletPlugin: makeWallet(),
                 },
-                walletPlugin: makeWallet(),
-            })
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session1)
-            const session2 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                data: {
-                    appId: 'app2',
+            const session2 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    data: {
+                        appId: 'app2',
+                    },
+                    walletPlugin: makeWallet(),
                 },
-                walletPlugin: makeWallet(),
-            })
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session2)
             const sessions = await sessionKit.getSessions()
             // Ensure the uniqueness rule was applied and both sessions exist
@@ -815,25 +848,31 @@ suite('kit', function () {
                 storage: new MockStorage(),
             })
             // Create two sessions for the same user with different appIds
-            const session1 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                data: {
-                    appId: 'app1',
+            const session1 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    data: {
+                        appId: 'app1',
+                    },
+                    walletPlugin: makeWallet(),
                 },
-                walletPlugin: makeWallet(),
-            })
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session1)
-            const session2 = new Session({
-                actor: 'session1',
-                permission: 'test',
-                chain: mockChainDefinition,
-                data: {
-                    appId: 'app2',
+            const session2 = new Session(
+                {
+                    actor: 'session1',
+                    permission: 'test',
+                    chain: mockChainDefinition,
+                    data: {
+                        appId: 'app2',
+                    },
+                    walletPlugin: makeWallet(),
                 },
-                walletPlugin: makeWallet(),
-            })
+                mockSessionOptions
+            )
             await sessionKit.persistSession(session2)
             const sessions = await sessionKit.getSessions()
             // Ensure the uniqueness rule was applied and both sessions exist

--- a/test/tests/kit.ts
+++ b/test/tests/kit.ts
@@ -476,6 +476,64 @@ suite('kit', function () {
                 assert.isTrue(restoredJUNGLE.chain.id.equals(Chains.Jungle4.id))
             }
         })
+        test('session from URL', async function () {
+            const sessionKit = new SessionKit(mockSessionKitArgs, {
+                ...mockSessionKitOptions,
+                acceptUrlSession: true,
+                storage: new MockStorage(),
+            })
+
+            // Ensure no sessions
+            const sessions = await sessionKit.restoreAll()
+            assert.lengthOf(sessions, 0)
+
+            // Mock window object for Node.js environment
+            if (typeof globalThis.window === 'undefined') {
+                ;(globalThis as any).window = {}
+            }
+
+            // Mock window.location with a writable href property
+            if (typeof (globalThis as any).window.location === 'undefined') {
+                ;(globalThis as any).window.location = {href: ''}
+            } else {
+                try {
+                    ;(globalThis as any).window.location.href =
+                        (globalThis as any).window.location.href || ''
+                } catch {
+                    ;(globalThis as any).window.location = {href: ''}
+                }
+            }
+
+            // Set the href to include an incomingWharfSession parameter
+            window.location.href =
+                'https://somewhere.com?incomingWharfSession=73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d104208d9c1754de3000000000090b1ca737b226964223a2277616c6c65742d706c7567696e2d707269766174656b6579222c2264617461223a7b22707269766174654b6579223a225056545f4b315f32355850314c7431527438376879796d6f755369654262676e554541657253317951486939777148433255656b326d677a48227d7d010f7b226669656c64223a22666f6f227d'
+
+            // Attempt to restore the session from the URL
+            const session = await sessionKit.restore()
+            if (!session) {
+                throw new Error('Failed to restore session from URL')
+            }
+
+            // Ensure session is correct
+            assert.isDefined(session)
+            assert.isTrue(session.chain.id.equals(mockChainDefinition.id), 'Incorrect chain')
+            assert.isTrue(session.actor.equals('wharfkit1111'), 'Incorrect actor')
+            assert.isTrue(session.permission.equals('test'), 'Incorrect permission')
+            assert.isTrue(
+                session.walletPlugin instanceof WalletPluginPrivateKey,
+                'Incorrect walletPlugin type'
+            )
+            assert.equal(session.data.field, 'foo', 'Incorrect session data')
+            assert.equal(session.walletPlugin.id, 'wallet-plugin-privatekey')
+            assert.equal(
+                session.walletPlugin.data.privateKey,
+                'PVT_K1_25XP1Lt1Rt87hyymouSieBbgnUEAerS1yQHi9wqHC2Uek2mgzH'
+            )
+
+            // Ensure session was persisted to storage
+            const sessionsAfter = await sessionKit.restoreAll()
+            assert.lengthOf(sessionsAfter, 1)
+        })
         test('no session returns undefined', async function () {
             const sessionKit = new SessionKit(mockSessionKitArgs, {
                 ...mockSessionKitOptions,

--- a/test/tests/kit.ts
+++ b/test/tests/kit.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai'
-import {Checksum256, PermissionLevel, TimePointSec} from '@wharfkit/antelope'
+import {Checksum256, Name, PermissionLevel, TimePointSec} from '@wharfkit/antelope'
 import {WalletPluginPrivateKey} from '@wharfkit/wallet-plugin-privatekey'
 
 import {
@@ -10,6 +10,7 @@ import {
     Logo,
     Session,
     SessionKit,
+    SessionType,
     UserInterfaceAccountCreationResponse,
     UserInterfaceLoginResponse,
 } from '$lib'
@@ -336,13 +337,41 @@ suite('kit', function () {
             assert.lengthOf(sessionsAfterLogout, 0)
         })
         test('session param', async function () {
-            const {session} = await sessionKit.login()
-            assertSessionMatchesMockSession(session)
+            const session1 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session1)
+
+            const session2 = new Session({
+                actor: 'session2',
+                permission: 'test',
+                chain: mockChainDefinition,
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session2)
+
+            const session3 = new Session({
+                actor: 'session3',
+                permission: 'test',
+                chain: Chains.EOS,
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session3)
+
             const sessionsBeforeLogout = await sessionKit.getSessions()
-            assert.lengthOf(sessionsBeforeLogout, 1)
-            await sessionKit.logout(session)
+            assert.lengthOf(sessionsBeforeLogout, 3)
+            assert.equal(sessionsBeforeLogout[0].actor, session1.actor)
+            assert.equal(sessionsBeforeLogout[1].actor, session2.actor)
+            assert.equal(sessionsBeforeLogout[2].actor, session3.actor)
+
+            await sessionKit.logout(session2)
             const sessionsAfterLogout = await sessionKit.getSessions()
-            assert.lengthOf(sessionsAfterLogout, 0)
+            assert.lengthOf(sessionsAfterLogout, 2)
+            assert.equal(sessionsAfterLogout[0].actor, session1.actor)
+            assert.equal(sessionsAfterLogout[1].actor, session3.actor)
         })
         test('serialized session param', async function () {
             const {session} = await sessionKit.login()
@@ -371,7 +400,7 @@ suite('kit', function () {
             })
             const {session} = await sessionKit.login()
             session.data.customField = 'data value'
-            sessionKit.persistSession(session)
+            await sessionKit.persistSession(session)
             const restored = await sessionKit.restore()
             if (!restored) {
                 throw new Error('Failed to restore session')
@@ -460,7 +489,7 @@ suite('kit', function () {
             assert.isTrue(sessions[2].actor.equals('mock3'))
             assert.isTrue(sessions[2].chain.id.equals(Chains.EOS.id))
 
-            const restoredEOS = await sessionKit.restore({chain: Chains.EOS})
+            const restoredEOS = await sessionKit.restore({chain: Chains.EOS.id})
             assert.isDefined(restoredEOS)
             if (restoredEOS) {
                 assert.instanceOf(restoredEOS, Session)
@@ -468,7 +497,7 @@ suite('kit', function () {
                 assert.isTrue(restoredEOS.chain.id.equals(Chains.EOS.id))
             }
 
-            const restoredJUNGLE = await sessionKit.restore({chain: Chains.Jungle4})
+            const restoredJUNGLE = await sessionKit.restore({chain: Chains.Jungle4.id})
             assert.isDefined(restoredJUNGLE)
             if (restoredJUNGLE) {
                 assert.instanceOf(restoredJUNGLE, Session)
@@ -483,13 +512,17 @@ suite('kit', function () {
                 storage: new MockStorage(),
             })
 
-            // Ensure no sessions
-            const sessions = await sessionKit.restoreAll()
-            assert.lengthOf(sessions, 0)
-
             // Mock window object for Node.js environment
             if (typeof globalThis.window === 'undefined') {
                 ;(globalThis as any).window = {}
+            }
+
+            // Mock window.history for Node.js environment
+            if (typeof (globalThis as any).window.history === 'undefined') {
+                ;(globalThis as any).window.history = {
+                    // eslint-disable-next-line @typescript-eslint/no-empty-function
+                    replaceState: () => {},
+                }
             }
 
             // Mock window.location with a writable href property
@@ -503,6 +536,10 @@ suite('kit', function () {
                     ;(globalThis as any).window.location = {href: ''}
                 }
             }
+
+            // Ensure no sessions
+            const sessions = await sessionKit.restoreAll()
+            assert.lengthOf(sessions, 0)
 
             // Set the href to include an incomingWharfSession parameter
             window.location.href =
@@ -623,7 +660,6 @@ suite('kit', function () {
                 storage: new MockStorage(),
             })
             const {session} = await sessionKit.login()
-            await sessionKit.persistSession(session)
             const restored = await sessionKit.restore()
             if (!restored) {
                 throw new Error('Failed to restore session')
@@ -683,11 +719,127 @@ suite('kit', function () {
                 chain: mockChainDefinition,
                 walletPlugin: makeWallet(),
             })
-            await sessionKit.persistSession(session2, false)
+            await sessionKit.persistSession(session2, {setAsDefault: false})
             const sessions = await sessionKit.getSessions()
             assert.lengthOf(sessions, 2)
             assert.equal(sessions[0].default, true)
             assert.equal(sessions[1].default, false)
+        })
+    })
+    suite('equalityFn', function () {
+        test('base equality check', async function () {
+            // The base equality uses a combination of chain, actor, and permission
+            const sessionKit = new SessionKit(mockSessionKitArgs, {
+                ...mockSessionKitOptions,
+                storage: new MockStorage(),
+            })
+            // Create two sessions for the same chain, actor, and permission but different appIds
+            const session1 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                data: {
+                    appId: 'app1',
+                },
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session1)
+            const session2 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                data: {
+                    appId: 'app2',
+                },
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session2)
+            const sessions = await sessionKit.getSessions()
+            // The base rules prevent duplicate sessions based on chain, actor, and permission only
+            // it ignores additional data like appId
+            assert.lengthOf(sessions, 1)
+            // The second session should have overwritten the first
+            assert.equal(sessions[0].data?.appId, 'app2')
+        })
+        test('custom equalityFn', async function () {
+            // This custom rule enforces custom uniqueness based on persisted appId
+            const equalityFn = (a: SessionType, b: SessionType) => {
+                const first = a instanceof Session ? a.serialize() : a
+                const second = b instanceof Session ? b.serialize() : b
+                const idsEqual = first.data?.appId === second.data?.appId
+                return (
+                    Checksum256.from(first.chain).equals(second.chain) &&
+                    Name.from(first.actor).equals(second.actor) &&
+                    Name.from(first.permission).equals(second.permission) &&
+                    idsEqual
+                )
+            }
+            const sessionKit = new SessionKit(mockSessionKitArgs, {
+                ...mockSessionKitOptions,
+                equalityFn, // Initialize with custom equality function
+                storage: new MockStorage(),
+            })
+            // Create two sessions for the same user with different appIds
+            const session1 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                data: {
+                    appId: 'app1',
+                },
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session1)
+            const session2 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                data: {
+                    appId: 'app2',
+                },
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session2)
+            const sessions = await sessionKit.getSessions()
+            // Ensure the uniqueness rule was applied and both sessions exist
+            assert.lengthOf(sessions, 2)
+            assert.equal(sessions[0].data?.appId, 'app1')
+            assert.equal(sessions[1].data?.appId, 'app2')
+        })
+        test('disable equality', async function () {
+            // This custom rule disables uniqueness entirely
+            const equalityFn = () => false
+            const sessionKit = new SessionKit(mockSessionKitArgs, {
+                ...mockSessionKitOptions,
+                equalityFn, // Initialize with custom equality function
+                storage: new MockStorage(),
+            })
+            // Create two sessions for the same user with different appIds
+            const session1 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                data: {
+                    appId: 'app1',
+                },
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session1)
+            const session2 = new Session({
+                actor: 'session1',
+                permission: 'test',
+                chain: mockChainDefinition,
+                data: {
+                    appId: 'app2',
+                },
+                walletPlugin: makeWallet(),
+            })
+            await sessionKit.persistSession(session2)
+            const sessions = await sessionKit.getSessions()
+            // Ensure the uniqueness rule was applied and both sessions exist
+            assert.lengthOf(sessions, 2)
+            assert.equal(sessions[0].data?.appId, 'app1')
+            assert.equal(sessions[1].data?.appId, 'app2')
         })
     })
     suite('setEndpoint', function () {

--- a/test/tests/session.ts
+++ b/test/tests/session.ts
@@ -598,7 +598,7 @@ suite('session', function () {
         test('encoded', async function () {
             const serialized = session.encode('serialized')
             const encoded = session.encode('encoded')
-            const fromEncoded = await kit.restore(encoded.args)
+            const fromEncoded = await kit.restore(encoded.serialized)
             if (!fromEncoded) {
                 throw new Error('Failed to restore session from encoded')
             }
@@ -615,7 +615,7 @@ suite('session', function () {
                 data: Bytes.from(url, 'hex'),
                 type: URLEncodedSession,
             })
-            const fromUrl = await kit.restore(reconstructed.args)
+            const fromUrl = await kit.restore(reconstructed.serialized)
             if (!fromUrl) {
                 throw new Error('Failed to restore session from url')
             }

--- a/test/tests/session.ts
+++ b/test/tests/session.ts
@@ -1,12 +1,20 @@
 import {assert} from 'chai'
 
-import SessionKit, {BaseTransactPlugin, ChainDefinition, Session, SessionOptions} from '$lib'
+import SessionKit, {
+    BaseTransactPlugin,
+    ChainDefinition,
+    Session,
+    SessionOptions,
+    URLEncodedSession,
+} from '$lib'
 import {
     ABI,
     ABIDef,
+    Bytes,
     FetchProvider,
     Name,
     PermissionLevel,
+    Serializer,
     Signature,
     TimePointSec,
 } from '@wharfkit/antelope'
@@ -37,9 +45,18 @@ const mockTransactOptions = {
 
 suite('session', function () {
     let session: Session
+    let kit: SessionKit
     setup(function () {
         // Establish new session before each test
-        session = new Session(mockSessionArgs, mockSessionOptions)
+        session = new Session(
+            {
+                ...mockSessionArgs,
+                data: {
+                    field: 'foo',
+                },
+            },
+            mockSessionOptions
+        )
     })
     nodejsUsage()
     suite('construct', function () {
@@ -533,6 +550,77 @@ suite('session', function () {
             // Check for that the API endpoint has changed
             const provider2 = testSession.client.provider as FetchProvider
             assert.equal(provider2.url, 'https://wax.greymass.com')
+        })
+    })
+    suite('encoded', function () {
+        setup(function () {
+            // Establish new session kit before each test
+            kit = new SessionKit(
+                {
+                    appName: 'demo.app',
+                    chains: [
+                        {
+                            id: '73e4385a2708e6d7048834fbc1079f2fabb17b3c125b146af438971e90716c4d',
+                            url: 'https://jungle4.greymass.com',
+                        },
+                    ],
+                    ui: new MockUserInterface(),
+                    walletPlugins: [makeWallet()],
+                },
+                {
+                    fetch: mockFetch, // Required for unit tests
+                    storage: new MockStorage(),
+                }
+            )
+        })
+        test('serialized', async function () {
+            const serialized = session.encode('serialized')
+            const fromSerialized = await kit.restore(serialized)
+            if (!fromSerialized) {
+                throw new Error('Failed to restore session from serialized')
+            }
+            assert.equal(
+                JSON.stringify(serialized),
+                JSON.stringify(fromSerialized.encode('serialized'))
+            )
+            assert.deepEqual(serialized, fromSerialized.encode('serialized'))
+        })
+        test('json', async function () {
+            const serialized = session.encode('serialized')
+            const json = session.encode('json')
+            const fromJson = await kit.restore(JSON.parse(json))
+            if (!fromJson) {
+                throw new Error('Failed to restore session from json')
+            }
+            assert.equal(JSON.stringify(serialized), JSON.stringify(fromJson.encode('serialized')))
+            assert.deepEqual(serialized, fromJson.encode('serialized'))
+        })
+        test('encoded', async function () {
+            const serialized = session.encode('serialized')
+            const encoded = session.encode('encoded')
+            const fromEncoded = await kit.restore(encoded.args)
+            if (!fromEncoded) {
+                throw new Error('Failed to restore session from encoded')
+            }
+            assert.equal(
+                JSON.stringify(serialized),
+                JSON.stringify(fromEncoded.encode('serialized'))
+            )
+            assert.deepEqual(serialized, fromEncoded.encode('serialized'))
+        })
+        test('url', async function () {
+            const serialized = session.encode('serialized')
+            const url = session.encode('url')
+            const reconstructed = Serializer.decode({
+                data: Bytes.from(url, 'hex'),
+                type: URLEncodedSession,
+            })
+            const fromUrl = await kit.restore(reconstructed.args)
+            if (!fromUrl) {
+                throw new Error('Failed to restore session from url')
+            }
+            assert.equal(JSON.stringify(serialized), JSON.stringify(fromUrl.encode('serialized')))
+            assert.deepEqual(serialized, fromUrl.encode('serialized'))
         })
     })
 })


### PR DESCRIPTION
- Prototype to intercept and use incoming sessions in URLs with restore
- Refactored `sessionKit.restore()`
- Added `equalityFn` for custom session comparisons (allows different uniqueness constraints in storage/restore/login/etc)
- Fixed issue with `setAsDefault` during restore/login